### PR TITLE
NFS persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # kubernetes-localhost
+## This branch is still in progress, once NFS persistent storage is ready, it will be merged with master.
 [![asciicast](https://asciinema.org/a/352272.svg)](https://asciinema.org/a/352272?autoplay=1&speed=5)
-Deploys Kubernetes with loadbalancer & dashboard on local machine using Vagrant.
+Deploys Kubernetes with loadbalancer, dashboard & persistent storage
+on local machine using Vagrant.
 
-By default you get 1 master, 2 working nodes, loadbalancer, and deployed dashboard.
+By default you get 1 master, 2 working nodes, NFS server, loadbalancer,
+and deployed dashboard.
 
 Version of deployed Kubernetes cluster is 1.18, version of Ubuntu VirtualBox
 image is 18.04.
+
+Persistent volume of 5GB, and 1GB persistent volume claim are provided automatically.
+For examples on how to use/create your own pv/pvc, check `manifests` directory.
 
 For bare-metal loadbalancing purposes [MetalLB](https://metallb.universe.tf/) is used.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and deployed dashboard.
 Version of deployed Kubernetes cluster is 1.18, version of Ubuntu VirtualBox
 image is 18.04.
 
-Persistent volume of 5GB, and 1GB persistent volume claim are provided automatically.
+Persistent volume `pv-nfs` and 5GB persistent volume claim `pvc-nfs` are provided automatically.
 For examples on how to use/create your own pv/pvc, check `manifests` directory.
 
 For bare-metal loadbalancing purposes [MetalLB](https://metallb.universe.tf/) is used.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # kubernetes-localhost
-## This branch is still in progress, once NFS persistent storage is ready, it will be merged with master.
 [![asciicast](https://asciinema.org/a/352272.svg)](https://asciinema.org/a/352272?autoplay=1&speed=5)
 Deploys Kubernetes with loadbalancer, dashboard & persistent storage
 on local machine using Vagrant.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Version of deployed Kubernetes cluster is 1.18, version of Ubuntu VirtualBox
 image is 18.04.
 
 Persistent volume `pv-nfs` and 5GB persistent volume claim `pvc-nfs` are provided automatically.
-For examples on how to use/create your own pv/pvc, check `manifests` directory.
+For examples on how to use/create your own pv/pvc, check `storage` directory.
 
 For bare-metal loadbalancing purposes [MetalLB](https://metallb.universe.tf/) is used.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,10 @@
 ## TODO:
 * [x]Deployment of Kubernetes Dashboard
-* [ ]Provision NFS for persistent storage purposes
+* [x]Provision NFS for persistent storage purposes
+    - [ ]Deploy this automatically during vagrant provisioning
 * [x]Setup loadbalancer
 * Manifests:
-    - [ ]Jenkins
-    - [x]Nginx
+    - [x]Nginx ephemeral
+    - [ ]Nginx with persistent storage
+    - [ ]Jenkins ephemeral
+    - [ ]Jenkins with persistent storage

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,9 @@ Vagrant.configure("2") do |config|
         master.vm.provision "ansible_local" do |ansible|
             ansible.playbook = "ansible/playbooks/dashboard/kubernetes-dashboard-install.yaml"
         end
+        master.vm.provision "ansible_local" do |ansible|
+            ansible.playbook = "ansible/playbooks/nfs/nfs-kubernetes-deploy.yaml"
+        end
 
     end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,24 @@ N = 2
 Vagrant.configure("2") do |config|
     config.ssh.insert_key = false
 
+    #TODO: Create NFS server for persistent storage
+    config.vm.define "k8s-nfs-server" do |nfs|
+        nfs.vm.box = IMAGE_NAME
+        nfs.vm.box_check_update = "True"
+        nfs.vm.network "private_network", ip: "192.168.100.150"
+        nfs.vm.hostname = "k8s-nfs-server"
+        nfs.vm.provider "virtualbox" do |nfs|
+          nfs.memory = "768"
+          nfs.cpus = 1
+        end
+        nfs.vm.provision "ansible_local" do |ansible|
+            ansible.playbook = "ansible/playbooks/nfs/nfs-server.yaml"
+            ansible.extra_vars = {
+                node_ip: "192.168.100.150",
+            }
+        end
+    end
+
     config.vm.define "k8s-master" do |master|
         master.vm.box = IMAGE_NAME
         master.vm.box_check_update = "True"
@@ -49,22 +67,4 @@ Vagrant.configure("2") do |config|
             end
         end
     end
-
-    #TODO: Create NFS server for persistent storage
-    #config.vm.define "k8s-nfs-server" do |nfs|
-    #    nfs.vm.box = IMAGE_NAME
-    #    nfs.vm.box_check_update = "True"
-    #    nfs.vm.network "private_network", ip: "192.168.90.1"
-    #    nfs.vm.hostname = "k8s-nfs-server"
-    #    nfs.vm.provider "virtualbox" do |nfs|
-    #      nfs.memory = "256"
-    #      nfs.cpus = 1
-    #    end
-    #    nfs.vm.provision "ansible" do |ansible|
-    #        ansible.playbook = "ansible/playbooks/nfs/nfs_server.yml"
-    #        ansible.extra_vars = {
-    #            node_ip: "192.168.50.200",
-    #        }
-    #    end
-    #end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,6 @@ N = 2
 Vagrant.configure("2") do |config|
     config.ssh.insert_key = false
 
-    #TODO: Create NFS server for persistent storage
     config.vm.define "k8s-nfs-server" do |nfs|
         nfs.vm.box = IMAGE_NAME
         nfs.vm.box_check_update = "True"

--- a/ansible/playbooks/nfs/nfs-kubernetes-deploy.yaml
+++ b/ansible/playbooks/nfs/nfs-kubernetes-deploy.yaml
@@ -1,0 +1,8 @@
+- hosts: all
+  gather_facts: no
+  become: True
+
+  tasks:
+    - name: Deploy NFS storage to Kubernetes
+      include_tasks: ../../tasks/nfs/nfs-kubernetes-deploy.yaml
+

--- a/ansible/playbooks/nfs/nfs-server.yaml
+++ b/ansible/playbooks/nfs/nfs-server.yaml
@@ -3,4 +3,6 @@
   become: True
 
   tasks:
-    - include_tasks: ../../tasks/nfs/nfs_server.yml
+    - name: Setup NFS server
+      include_tasks: ../../tasks/nfs/nfs-server.yaml
+

--- a/ansible/tasks/kubernetes/kubernetes-nodes.yaml
+++ b/ansible/tasks/kubernetes/kubernetes-nodes.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Apt over HTTPS
+- name: Apt over HTTPS and nfs-common
   apt:
     name: [
       'apt-transport-https',
@@ -7,7 +7,8 @@
       'gnupg2',
       'curl',
       'gnupg-agent',
-      'software-properties-common']
+      'software-properties-common',
+      'nfs-common']
     state: present
     update_cache: yes
 

--- a/ansible/tasks/nfs/nfs-kubernetes-deploy.yaml
+++ b/ansible/tasks/nfs/nfs-kubernetes-deploy.yaml
@@ -1,0 +1,20 @@
+---
+- name: Upload storage manifests
+  copy:
+    src: "{{ item }}"
+    dest: /home/vagrant
+    owner: vagrant
+    group: vagrant
+    mode: '0644'
+  with_items:
+    - ../../../storage/persistent-volume.yaml
+    - ../../../storage/persistent-volume-claim.yaml
+
+- name: Apply persistent volume
+  command: kubectl apply -f /home/vagrant/persistent-volume.yaml
+  become_user: vagrant
+
+- name: Apply persistent volume claim
+  command: kubectl apply -f /home/vagrant/persistent-volume-claim.yaml
+  become_user: vagrant
+

--- a/ansible/tasks/nfs/nfs-server.yaml
+++ b/ansible/tasks/nfs/nfs-server.yaml
@@ -1,29 +1,37 @@
-- name: "Update packages"
+- name: Update packages
   apt:
     update_cache: yes
     cache_valid_time: 3600
     upgrade: safe
 
-- name: "Install packages"
+- name: Install packages
   apt:
     name: nfs-kernel-server
     state: present
 
-- name: "Setup mount"
+- name: Enable service
+  systemd:
+    name: nfs-server
+    state: started
+    enabled: yes
+
+- name: Setup mount
   file:
     state: directory
     path: /var/nfs/kubernetes
     mode: 0755
 
-- name: "Configure nfs export"
+- name: Configure nfs export
   blockinfile:
     path: /etc/exports
-    marker: "#### Ansible"
     state: present
     block: |
-      /var/nfs/kubernetes    172.40.50.0/24(rw,sync,no_subtree_check)
+      /var/nfs/kubernetes    192.168.100.0/24(rw,sync,no_subtree_check,insecure)
 
-- name: "Restart the service"
+- name: Export directory
+  command: exportfs -a
+
+- name: Restart the service
   systemd:
     name: nfs-kernel-server
     state: restarted

--- a/storage/persistent-volume-claim.yaml
+++ b/storage/persistent-volume-claim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-nfs
+spec:
+  storageClassName: nfs
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/storage/persistent-volume-claim.yaml
+++ b/storage/persistent-volume-claim.yaml
@@ -8,5 +8,5 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 1Gi
+      storage: 5Gi
 

--- a/storage/persistent-volume.yaml
+++ b/storage/persistent-volume.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-nfs
+  labels:
+    volume: nfs
+spec:
+  storageClassName: nfs
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: 192.168.100.150
+    path: "/var/nfs/kubernetes"


### PR DESCRIPTION
Provisioning of NFS storage for persistent storage purposes. This is static way for provisioning volumes, if there's need I might switch it to StorageClass in order to enable dynamically provisioned storage for pods, deployments, etc...

- Adding new NFS server to be deployed with already present master and two worker nodes.
- Automatic provisioning, and setup of NFS server.
- Updating documentation.
